### PR TITLE
CRITICAL FIX: Disable automatic branch creation and fix labels

### DIFF
--- a/.github/workflows/issue-to-implementation.yml
+++ b/.github/workflows/issue-to-implementation.yml
@@ -167,7 +167,15 @@ jobs:
               });
             }
             
+      # DISABLED: Branch/PR creation moved to /work command (Track 1 workflow)
+      # Issues should NOT create branches automatically
+      - name: Skip automatic branch creation
+        run: |
+          echo "Branch and PR creation happens via /work command, not automatically"
+          echo "This prevents unused branches from accumulating"
+          
       - name: Create implementation branch and draft PR
+        if: false  # DISABLED - keeping code for reference
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -42,7 +42,8 @@ jobs:
             // Define allowed labels directly (simpler than reading file)
             const allowedLabels = [
               'bug', 'feature', 'enhancement', 'refactor', 
-              'documentation', 'test', 'chore', 'dependencies'
+              'documentation', 'test', 'chore', 'dependencies',
+              'draft', 'exploration', 'research', 'not-ready', 'quick-fix'
             ];
             
             // Get current labels


### PR DESCRIPTION
## Critical Workflow Fixes

### Problems Fixed:
1. **Issues were creating branches automatically** - DISABLED
2. **Label sync missing new labels** - ADDED draft, exploration, research, not-ready, quick-fix

### What This Fixes:
- Stops the 72+ unused branches problem
- Issues no longer create branches (only /work command does)
- Allows proper two-track workflow labels

## Checklist
- [x] Disabled automatic branch/PR creation in issue-to-implementation.yml
- [x] Added missing labels to label-sync.yml
- [x] Ready to merge ASAP