### PR TITLE
Re-enable project and auto-assign workflows

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,8 +14,6 @@ permissions:
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
-    # DISABLED: Running manual workflow for now
-    if: false  # Manual assignment for now
     
     steps:
       - name: Check if creator is team member

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -50,8 +50,7 @@ jobs:
   add-to-project:
     name: Add Issue to Project
     runs-on: ubuntu-latest
-    # DISABLED: Running manual workflow for now
-    if: false  # Was: (github.event.issue && github.event.action == 'opened') || github.event_name == 'workflow_dispatch'
+    if: (github.event.issue && github.event.action == 'opened') || github.event_name == 'workflow_dispatch'
     outputs:
       item-id: ${{ steps.add-to-project.outputs.itemId }}
     


### PR DESCRIPTION
## Re-enabling workflows for testing

- Project automation back online
- Auto-assign back online
- Issue-to-implementation still disabled (creates branches too early)

## Checklist
- [x] Implementation complete
- [x] Tests pass
- [x] Documentation updated
- [x] Ready to merge