### PR TITLE
fix: Add title prefix to feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature / Enhancement
 description: Suggest a new feature or improvement
-title: ""
+title: "[FEATURE]: "
 labels: ["enhancement"]
 body:
   - type: dropdown


### PR DESCRIPTION
Quick fix to add title prefix to feature_request.yml template to ensure it shows up properly on GitHub.

## Changes
- [x] Added `[FEATURE]: ` title prefix to match other templates
- [x] This should make the template visible on GitHub's issue creation page