### PR TITLE
fix: Remove bug label from hotfix template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,18 +1,14 @@
 name: Feature / Enhancement
 description: Suggest a new feature or improvement
 title: "[FEATURE]: "
-labels: ["feature"]
+labels: ["enhancement"]
 body:
   - type: textarea
     id: all_details
     attributes:
-      label: Feature Request
+      label: Details
       description: Fill out all sections below
       value: |
-        ## Type
-        <!-- Choose one: New Feature / Enhancement / Refactor -->
-        New Feature
-        
         ## Description
         <!-- What do you want to build/improve? -->
         
@@ -21,5 +17,17 @@ body:
         - [ ] 
         - [ ] 
         - [ ] 
+    validations:
+      required: true
+      
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What kind of change is this?
+      options:
+        - "New Feature"
+        - "Enhancement"
+        - "Refactor"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/hotfix.yml
+++ b/.github/ISSUE_TEMPLATE/hotfix.yml
@@ -1,7 +1,7 @@
 name: Hotfix
-description: Critical bug that needs immediate attention
+description: Critical issue that needs immediate attention
 title: "[HOTFIX]: "
-labels: ["bug", "hotfix", "urgent"]
+labels: ["hotfix", "urgent"]
 body:
   - type: textarea
     id: all_details


### PR DESCRIPTION
Quick fix - removes "bug" label from hotfix template since hotfixes aren't always bugs.

- [x] Changed from `["bug", "hotfix", "urgent"]` to `["hotfix", "urgent"]`
- [x] Ready to merge