### PR TITLE
HOTFIX: Correct Copilot bot username detection

### DIFF
--- a/.github/workflows/auto-approve-copilot-workflows.yml
+++ b/.github/workflows/auto-approve-copilot-workflows.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run for Copilot PRs
     if: |
+      github.event.pull_request.user.login == 'app/copilot-swe-agent' ||
       github.event.pull_request.user.login == 'github-actions[bot]' ||
       github.event.pull_request.user.login == 'copilot[bot]' ||
       github.event.pull_request.user.login == 'github-copilot[bot]' ||

--- a/.github/workflows/copilot-status-reporter.yml
+++ b/.github/workflows/copilot-status-reporter.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     # Only run for Copilot-created PRs
     if: |
+      github.event.pull_request.user.login == 'app/copilot-swe-agent' ||
       github.event.pull_request.user.login == 'copilot[bot]' ||
       github.event.pull_request.user.login == 'github-copilot[bot]' ||
-      github.event.pull_request.user.type == 'Bot' ||
       startsWith(github.event.pull_request.head.ref, 'copilot/')
     
     steps:


### PR DESCRIPTION
## Critical Fix

The workflows were checking for wrong bot usernames. 

**The actual Copilot username is:** `app/copilot-swe-agent`
**We were checking for:** `copilot[bot]`

This hotfix updates both workflows to detect the correct username.

## Changes
- Updated copilot-status-reporter.yml 
- Updated auto-approve-copilot-workflows.yml

## Testing
After merging, the existing Copilot PR #149 should have its workflows auto-approved.